### PR TITLE
LAAS-1007: Don't throw an error if there's already an in-flight request

### DIFF
--- a/src/ui/public/courier/fetch/request/request.js
+++ b/src/ui/public/courier/fetch/request/request.js
@@ -23,7 +23,14 @@ define(function (require) {
 
     AbstractReq.prototype.start = function () {
       if (this.started) {
-        throw new TypeError('Unable to start request because it has already started');
+        // This is a hack to workaround #6161 (in elastic/kibana repo)
+        //
+        // Normally we would:
+        //  throw new TypeError('...');
+        //
+        // We purposely don't throw an error to prevent users from being thrown
+        // into the Oops screen (for reasons described in the issue).
+        return;
       }
 
       this.started = true;


### PR DESCRIPTION
Issue described in elastic/kibana#6161. But it seems this issue wasn't backported to 4.4.2 (a recent upgrade we did).

We fixed this (internally) by sprinkling a lot of the same type of change (i.e. changing a `throw new TypeError()` to a blank `return`. But this part was missed en route to the 4.4.2 upgrade.
